### PR TITLE
Add outputs for access keys.

### DIFF
--- a/s3_buckets/main.tf
+++ b/s3_buckets/main.tf
@@ -63,3 +63,15 @@ resource "aws_s3_bucket" "b" {
   count = "${length(split(",", var.buckets))}"
   bucket = "${element(split(",", var.buckets), count.index)}"
 }
+
+output "users" {
+  value = "${join(" ", aws_iam_user.s3_users.*.name)}"
+}
+
+output "keys" {
+  value = "${join(" ", aws_iam_access_key.s3_users.*.id)}"
+}
+
+output "secrets" {
+  value = "${join(" ", aws_iam_access_key.s3_users.*.secret)}"
+}


### PR DESCRIPTION
Why:
- It's useful to have quick access to the user, keys, and secrets of the
  newly created s3 users.

This change addresses the need by:
- Add outputs for username, access key, and access secret.
