### PR TITLE
Create a S3 Bucket Users Module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.terraform/
+*.tfstate*
+*.tfvars

--- a/s3_bucket_users/README.md
+++ b/s3_bucket_users/README.md
@@ -1,0 +1,22 @@
+# S3 Bucket Users Module
+
+A [terraform module](https://www.terraform.io/docs/modules/usage.html) for
+easily creating an IAM user with access to only a single S3 bucket.
+
+## Usage
+
+Add the following to your terraform file. You will need to have the aws vars
+defined as well as replace the bucket value with a comma seperated list of the
+buckets for which you'd like to create IAM users (it will also work with a
+single bucket).
+
+```hcl
+module "s3_bucket_users" {
+  source = "github.com/spartansystems/terraform-modules//s3_bucket_users"
+  buckets = "first_bucket,second_bucket"
+  iam_user_group_name = "s3_bucket_users_group"
+  aws_access_key = "${var.aws_access_key}"
+  aws_secret_key = "${var.aws_secret_key}"
+  aws_region = "${var.aws_region}"
+}
+```

--- a/s3_bucket_users/main.tf
+++ b/s3_bucket_users/main.tf
@@ -1,0 +1,75 @@
+variable "buckets" {}
+variable "iam_user_group_name" {
+  default = "s3_users"
+}
+variable "aws_access_key" {}
+variable "aws_secret_key" {}
+variable "aws_region" {
+  default = "us-east-1"
+}
+
+provider "aws" {
+  access_key = "${var.aws_access_key}"
+  secret_key = "${var.aws_secret_key}"
+  region = "${var.aws_region}"
+}
+
+resource "aws_iam_user" "s3_users" {
+  count = "${length(split(",", var.buckets))}"
+  name = "${element(split(",", var.buckets), count.index)}"
+}
+
+resource "aws_iam_access_key" "s3_users" {
+  count = "${length(split(",", var.buckets))}"
+  user = "${element(split(",", var.buckets), count.index)}"
+  depends_on = ["aws_iam_user.s3_users"]
+}
+
+resource "aws_iam_group_membership" "s3_users" {
+  name = "tf-s3-group-membership"
+  users = ["${aws_iam_user.s3_users.*.name}"]
+  group = "${aws_iam_group.s3_users.name}"
+}
+
+resource "aws_iam_group_policy" "s3_users" {
+  name = "s3_users_policy"
+  group = "${aws_iam_group.s3_users.name}"
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket",
+                "s3:GetBucketLocation"
+            ],
+            "Resource": "arn:aws:s3:::$${aws:username}"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:*"
+            ],
+            "Resource": "arn:aws:s3:::$${aws:username}/*"
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_group" "s3_users" {
+  name = "${var.iam_user_group_name}"
+}
+
+output "users" {
+  value = "${join(" ", aws_iam_user.s3_users.*.name)}"
+}
+
+output "keys" {
+  value = "${join(" ", aws_iam_access_key.s3_users.*.id)}"
+}
+
+output "secrets" {
+  value = "${join(" ", aws_iam_access_key.s3_users.*.secret)}"
+}

--- a/s3_buckets/README.md
+++ b/s3_buckets/README.md
@@ -16,6 +16,7 @@ buckets you'd like to create (it will also work with a single bucket).
 module "s3_buckets" {
   source = "github.com/spartansystems/terraform-modules//s3_buckets"
   buckets = "first_bucket,second_bucket"
+  iam_user_group_name = "s3_buckets_group"
   aws_access_key = "${var.aws_access_key}"
   aws_secret_key = "${var.aws_secret_key}"
   aws_region = "${var.aws_region}"

--- a/s3_buckets/main.tf
+++ b/s3_buckets/main.tf
@@ -1,4 +1,7 @@
 variable "buckets" {}
+variable "iam_user_group_name" {
+  default = "s3_users"
+}
 variable "aws_access_key" {}
 variable "aws_secret_key" {}
 variable "aws_region" {
@@ -11,52 +14,13 @@ provider "aws" {
   region = "${var.aws_region}"
 }
 
-resource "aws_iam_user" "s3_users" {
-  count = "${length(split(",", var.buckets))}"
-  name = "${element(split(",", var.buckets), count.index)}"
-}
-
-resource "aws_iam_access_key" "s3_users" {
-  count = "${length(split(",", var.buckets))}"
-  user = "${element(split(",", var.buckets), count.index)}"
-  depends_on = ["aws_iam_user.s3_users"]
-}
-
-resource "aws_iam_group_membership" "s3_users" {
-  name = "tf-s3-group-membership"
-  users = ["${aws_iam_user.s3_users.*.name}"]
-  group = "${aws_iam_group.s3_users.name}"
-}
-
-resource "aws_iam_group_policy" "s3_users" {
-  name = "s3_users_policy"
-  group = "${aws_iam_group.s3_users.name}"
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "s3:ListBucket",
-                "s3:GetBucketLocation"
-            ],
-            "Resource": "arn:aws:s3:::$${aws:username}"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "s3:*"
-            ],
-            "Resource": "arn:aws:s3:::$${aws:username}/*"
-        }
-    ]
-}
-EOF
-}
-
-resource "aws_iam_group" "s3_users" {
-  name = "s3_users"
+module "s3_bucket_users" {
+  source = "../s3_bucket_users"
+  buckets = "${var.buckets}"
+  iam_user_group_name = "${var.iam_user_group_name}"
+  aws_access_key = "${var.aws_access_key}"
+  aws_secret_key = "${var.aws_secret_key}"
+  aws_region = "${var.aws_region}"
 }
 
 resource "aws_s3_bucket" "b" {
@@ -65,13 +29,13 @@ resource "aws_s3_bucket" "b" {
 }
 
 output "users" {
-  value = "${join(" ", aws_iam_user.s3_users.*.name)}"
+  value = "${join(" ", module.s3_bucket_users.users)}"
 }
 
 output "keys" {
-  value = "${join(" ", aws_iam_access_key.s3_users.*.id)}"
+  value = "${join(" ", module.s3_bucket_users.keys)}"
 }
 
 output "secrets" {
-  value = "${join(" ", aws_iam_access_key.s3_users.*.secret)}"
+  value = "${join(" ", module.s3_bucket_users.secrets)}"
 }

--- a/test/s3_bucket_users/main.tf
+++ b/test/s3_bucket_users/main.tf
@@ -1,0 +1,8 @@
+module "s3_bucket_users" {
+  source = "../../s3_bucket_users"
+  buckets = "first_test_user,second_test_user"
+  iam_user_group_name = "s3_bucket_users_group"
+  aws_access_key = "${var.aws_access_key}"
+  aws_secret_key = "${var.aws_secret_key}"
+  aws_region = "${var.aws_region}"
+}

--- a/test/s3_bucket_users/variables.tf
+++ b/test/s3_bucket_users/variables.tf
@@ -1,0 +1,5 @@
+variable "aws_access_key" {}
+variable "aws_secret_key" {}
+variable "aws_region" {
+  default = "us-east-1"
+}

--- a/test/s3_buckets/main.tf
+++ b/test/s3_buckets/main.tf
@@ -1,0 +1,7 @@
+module "s3_buckets" {
+  source = "../../s3_buckets"
+  buckets = "first_test_bucket,second_test_bucket"
+  aws_access_key = "${var.aws_access_key}"
+  aws_secret_key = "${var.aws_secret_key}"
+  aws_region = "${var.aws_region}"
+}

--- a/test/s3_buckets/variables.tf
+++ b/test/s3_buckets/variables.tf
@@ -1,0 +1,5 @@
+variable "aws_access_key" {}
+variable "aws_secret_key" {}
+variable "aws_region" {
+  default = "us-east-1"
+}


### PR DESCRIPTION
Why:
- There are times that S3 bucket resource management should be specified
  directly in your tf files so you can customize it.

This change addresses the need by:
- Move IAM resources into a new module and use that module.
- Add a test directory for testing modules ad hoc with `terraform plan`
